### PR TITLE
Use absolute url for thumbnails

### DIFF
--- a/src/SeoBundle/MetaData/Integrator/OpenGraphIntegrator.php
+++ b/src/SeoBundle/MetaData/Integrator/OpenGraphIntegrator.php
@@ -232,7 +232,7 @@ class OpenGraphIntegrator implements IntegratorInterface
         if ($asset instanceof Asset\Image) {
             $thumbnail = $asset->getThumbnail($this->configuration['facebook_image_thumbnail']);
             if ($thumbnail instanceof Asset\Image\Thumbnail) {
-                $imagePath = $thumbnail->getPath(false);
+                $imagePath = \Pimcore\Tool::getHostUrl() . $thumbnail->getPath(false);
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #9

OpenGraph strictly specifies that relative urls are not allowed for the og:image tag.