### PR TITLE
Use translation for tab title

### DIFF
--- a/src/SeoBundle/Resources/public/js/metaData/documentMetaDataPanel.js
+++ b/src/SeoBundle/Resources/public/js/metaData/documentMetaDataPanel.js
@@ -50,7 +50,7 @@ Seo.MetaData.DocumentMetaDataPanel = Class.create(Seo.MetaData.AbstractMetaDataP
 
         tabPanel.items.each(function (tab) {
             if (tab.iconCls.indexOf('page_settings') !== -1) {
-                tab.setTitle('Settings');
+                tab.setTitle(t('settings'));
                 tab.items.each(function (tabItem) {
                     if (tabItem.itemId === 'metaDataPanel') {
                         tab.remove(tabItem);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

The original title of the tab is translated: `t('SEO') + ' &amp; ' + t('settings')`.
If the default pimcore seo panel is hidden, the title is overridden to be simple "Settings" without the use of any translation.
