### PR TITLE
fix: rename default Coreshop SEO thumbnail

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -3,6 +3,7 @@
 ## 2.1.0
 - [BUGFIX] Fix Array Merge Process [#32](https://github.com/dachcom-digital/pimcore-seo/issues/32)
 - [BUGFIX] Avoid triggering deprecation message on isMasterRequest() [#36](https://github.com/dachcom-digital/pimcore-seo/pull/36)
+- [BUGFIX] Support CoreShop 3 Thumbnails [@dkarlovi](https://github.com/dachcom-digital/pimcore-seo/pull/30)
 
 ## Migrating from Version 1.x to Version 2.0.0
 

--- a/src/SeoBundle/MetaData/Extractor/ThirdParty/CoreShop/OGExtractor.php
+++ b/src/SeoBundle/MetaData/Extractor/ThirdParty/CoreShop/OGExtractor.php
@@ -32,7 +32,7 @@ final class OGExtractor implements ExtractorInterface
         }
 
         if (method_exists($element, 'getImage') && !empty($element->getImage())) {
-            $ogImage = Tool::getHostUrl() . $element->getImage()->getThumbnail('seo');
+            $ogImage = Tool::getHostUrl() . $element->getImage()->getThumbnail('coreshop_seo');
             $seoMetadata->addExtraProperty('og:image', $ogImage);
         }
     }


### PR DESCRIPTION
Coreshop 3.0 defaults to `coreshop_seo`

https://github.com/coreshop/CoreShop/blob/bb59f7062e0da2cb1cf34a4d40066472fe43db4e/src/CoreShop/Bundle/FrontendBundle/Resources/install/pimcore/image-thumbnails.yml#L92

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | N/A
