### PR TITLE
Use isset check instead of !== null in ArrayHelper

### DIFF
--- a/src/SeoBundle/Helper/ArrayHelper.php
+++ b/src/SeoBundle/Helper/ArrayHelper.php
@@ -104,7 +104,7 @@ class ArrayHelper
 
         $cleanData = [];
         foreach ($field as $row) {
-            if ($row['value'] !== null) {
+            if (isset($row['value'])) {
                 $cleanData[] = $row;
             }
         }


### PR DESCRIPTION
Saving og:image tag fails otherwise

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #32 


The isset() check will not throw an exception when the 'value' key is not set, it also checks for null so in my opinion this check would be a better alternative.

Before the change this array would not properly save an og:image tag, after my change it saves correctly and issue #32 is solved :)

```php
[
  'property' => 'og:image',
  'value' => [
    'id' => $header->getId(),
    'path' => $header->getCurrentFullPath(),
    'type' => 'asset',
    'subtype' => 'image',
  ],
];
```
