### PR TITLE
Avoid triggering deprecation message on isMasterRequest()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,7 @@
 
 ## 2.1.0
 - [BUGFIX] Fix Array Merge Process [#32](https://github.com/dachcom-digital/pimcore-seo/issues/32)
+- [BUGFIX] Avoid triggering deprecation message on isMasterRequest() [#36](https://github.com/dachcom-digital/pimcore-seo/pull/36)
 
 ## Migrating from Version 1.x to Version 2.0.0
 

--- a/src/SeoBundle/EventListener/AutoMetaDataAttachListener.php
+++ b/src/SeoBundle/EventListener/AutoMetaDataAttachListener.php
@@ -52,6 +52,12 @@ class AutoMetaDataAttachListener implements EventSubscriberInterface
             return;
         }
 
+        // Since symfony/http-kernel 5.3, remove function_exists() once symfony/http-kernel 5.3 is no longer supported
+        if (method_exists($event, 'isMainRequest') && $event->isMainRequest()) {
+            return;
+        }
+
+        // Remove once symfony/http-kernel 5.3 is no longer supported, use isMainRequest()
         if ($event->isMasterRequest() === false) {
             return;
         }

--- a/src/SeoBundle/EventListener/AutoMetaDataAttachListener.php
+++ b/src/SeoBundle/EventListener/AutoMetaDataAttachListener.php
@@ -52,13 +52,7 @@ class AutoMetaDataAttachListener implements EventSubscriberInterface
             return;
         }
 
-        // Since symfony/http-kernel 5.3, remove function_exists() once symfony/http-kernel 5.3 is no longer supported
-        if (method_exists($event, 'isMainRequest') && $event->isMainRequest()) {
-            return;
-        }
-
-        // Remove once symfony/http-kernel 5.3 is no longer supported, use isMainRequest()
-        if ($event->isMasterRequest() === false) {
+        if ($event->isMainRequest() === false) {
             return;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no


Avoid deprecation message by trying to use `isMainRequest()` prior to `isMasterRequest()`