### PR TITLE
[HtmlTagIntegrator] Add presets (V1)

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,10 @@ Just click the "update" button or execute the migration command to finish the bu
 
 ***
 
+#### Version 1.2
+- Support Pimcore 6.9 only
+- Add presets to HTML tag integrator [#43](https://github.com/dachcom-digital/pimcore-seo/pull/43)
+
 #### Update from Version 1.1.0 to Version 1.1.1
 - **[ENHANCEMENT]** Improve Dependency Check [#20](https://github.com/dachcom-digital/pimcore-seo/issues/20)
 

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     "require": {
         "google/apiclient": "^2.0",
-        "pimcore/pimcore": "^6.0",
+        "pimcore/pimcore": "^6.9",
         "doctrine/orm": "^2.7"
     },
     "require-dev": {

--- a/docs/MetaData/Integrator/14_HtmlTagIntegrator.md
+++ b/docs/MetaData/Integrator/14_HtmlTagIntegrator.md
@@ -14,3 +14,34 @@ seo:
             enabled_integrator:
                 -   integrator_name: html_tag
 ```
+
+## Extended Configuration
+
+```yaml
+seo:
+    meta_data_configuration:
+        meta_data_integrator:
+            enabled_integrator:
+                -   integrator_name: html_tag
+                    integrator_config:
+                        presets_only_mode: false
+                        presets:
+                            -
+                                label: 'Robots No-Index'
+                                value: '<meta name="robots" content="noindex, nofollow">'
+                                icon_class: 'pimcore_icon_stop'
+                            -   
+                                label: 'Secret Meta-Link'
+                                value: '<meta name="secret" content="secret-thing">'
+```
+
+### presets
+If defined, the user is able to add predefined presets. They can only be added and not edited!
+
+![image](https://user-images.githubusercontent.com/700119/202385523-b748a0d3-56c3-4403-980f-53c60c2b45e8.png)
+
+![image](https://user-images.githubusercontent.com/700119/202278570-51d1ed18-e323-4704-b0d7-09649fca2281.png)
+
+### presets_only_mode
+If set to `true`, the user is not able to add custom tags but only presets:
+![image](https://user-images.githubusercontent.com/700119/202385300-61f5d884-8d4f-4353-8c0f-5cc6c79a7b7c.png)

--- a/src/SeoBundle/MetaData/Integrator/HtmlTagIntegrator.php
+++ b/src/SeoBundle/MetaData/Integrator/HtmlTagIntegrator.php
@@ -20,7 +20,9 @@ class HtmlTagIntegrator implements IntegratorInterface
         return [
             'hasLivePreview'       => false,
             'livePreviewTemplates' => [],
-            'useLocalizedFields'   => false
+            'useLocalizedFields'   => false,
+            'presets'              => $this->configuration['presets'],
+            'presets_only_mode'    => $this->configuration['presets_only_mode'],
         ];
     }
 
@@ -102,6 +104,13 @@ class HtmlTagIntegrator implements IntegratorInterface
      */
     public static function configureOptions(OptionsResolver $resolver)
     {
-        // no options here.
+        $resolver->setDefaults([
+            'presets_only_mode' => false,
+            'presets'           => [],
+        ]);
+
+        $resolver->setRequired(['presets_only_mode']);
+        $resolver->setAllowedTypes('presets_only_mode', ['bool']);
+        $resolver->setAllowedTypes('presets', ['array']);
     }
 }

--- a/src/SeoBundle/MetaData/MetaDataProvider.php
+++ b/src/SeoBundle/MetaData/MetaDataProvider.php
@@ -2,8 +2,8 @@
 
 namespace SeoBundle\MetaData;
 
-use Pimcore\Templating\Helper\HeadMeta;
-use Pimcore\Templating\Helper\HeadTitle;
+use Pimcore\Twig\Extension\Templating\HeadMeta;
+use Pimcore\Twig\Extension\Templating\HeadTitle;
 use SeoBundle\MetaData\Extractor\ExtractorInterface;
 use SeoBundle\Middleware\MiddlewareDispatcherInterface;
 use SeoBundle\Registry\MetaDataExtractorRegistryInterface;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no

PR for V1 (See https://github.com/dachcom-digital/pimcore-seo/pull/42)

PS: The reason for my issue not rendering the tags was because the old implementation was referencing the deprecated `Pimcore\Templating\Helper\HeadMeta` and `Pimcore\Templating\Helper\HeadTitle` classes. Once I replaced them with the newer `Pimcore\Twig\Extension\Templating\HeadMeta` and `Pimcore\Twig\Extension\Templating\HeadTitle` it worked flawlessly. 😉