### PR TITLE
Fix Symfony Console deprecation in QueuedIndexDataCommand

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,8 @@
 # Upgrade Notes
 
+## 3.0.3
+- Fix Symfony Console deprecation in QueuedIndexDataCommand [@NiklasBr](https://github.com/dachcom-digital/pimcore-seo/pull/63)
+
 ## 3.0.2
 - Fix og:image URL for CoreShop third party og tag [@breakone ](https://github.com/dachcom-digital/pimcore-seo/pull/61)
 - FAdd ext-dom to composer.json [@NiklasBr](https://github.com/dachcom-digital/pimcore-seo/pull/51)

--- a/src/Command/QueuedIndexDataCommand.php
+++ b/src/Command/QueuedIndexDataCommand.php
@@ -3,30 +3,27 @@
 namespace SeoBundle\Command;
 
 use SeoBundle\Queue\QueueDataProcessorInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'seo:check-index-queue',
+    description: 'For internal use only',
+    hidden: true,
+)]
 class QueuedIndexDataCommand extends Command
 {
-    protected static $defaultName = 'seo:check-index-queue';
-    protected static $defaultDescription = 'For internal use only';
-
     public function __construct(protected QueueDataProcessorInterface $dataProcessor)
     {
         parent::__construct();
-        $this->dataProcessor = $dataProcessor;
-    }
-
-    protected function configure(): void
-    {
-        $this->setHidden(true);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->dataProcessor->process([]);
 
-        return 0;
+        return self::SUCCESS;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | n/a

Fixes the following deprecation warnings:

_PHP Deprecated: Since symfony/console 6.1: Relying on the static property "$defaultName" for setting a command name is deprecated. Add the "Symfony\Component\Console\Attribute\AsCommand" attribute to the "SeoBundle\Command\QueuedIndexDataCommand" class instead. in /var/www/pimcore/vendor/symfony/contracts/Deprecation/function.php on line 25
PHP Deprecated: Since symfony/console 6.1: Relying on the static property "$defaultDescription" for setting a command description is deprecated. Add the "Symfony\Component\Console\Attribute\AsCommand" attribute to the "SeoBundle\Command\QueuedIndexDataCommand" class instead. in /var/www/pimcore/vendor/symfony/contracts/Deprecation/function.php on line 25_
