### PR TITLE
introduce release type

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The last SEO Bundle for pimcore you'll ever need!
 
 ```json
 "require" : {
-    "dachcom-digital/seo" : "~3.0.0",
+    "dachcom-digital/seo" : "~3.1.0",
 }
 ```
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,8 @@
 # Upgrade Notes
 
+## 3.1.0
+- **[NEW FEATURE]** Add Release Type to allow draft/public states [@64](https://github.com/dachcom-digital/pimcore-seo/issues/64)
+
 ## 3.0.3
 - Fix Symfony Console deprecation in QueuedIndexDataCommand [@NiklasBr](https://github.com/dachcom-digital/pimcore-seo/pull/63)
 

--- a/config/doctrine/model/ElementMetaData.orm.yml
+++ b/config/doctrine/model/ElementMetaData.orm.yml
@@ -24,6 +24,12 @@ SeoBundle\Model\ElementMetaData:
             column: data
             nullable: false
             type: array
+        releaseType:
+            column: release_type
+            nullable: false
+            type: string
+            options:
+                default: 'public'
     uniqueConstraints:
         element_type_id_integrator:
-            columns: [element_type, element_id, integrator]
+            columns: [element_type, element_id, integrator, release_type]

--- a/public/js/metaData/abstractMetaDataPanel.js
+++ b/public/js/metaData/abstractMetaDataPanel.js
@@ -5,6 +5,7 @@ Seo.MetaData.AbstractMetaDataPanel = Class.create({
     element: null,
     integrator: [],
 
+    draftNode: null,
     layout: null,
     tabPanel: null,
     renderAsTab: false,
@@ -67,7 +68,24 @@ Seo.MetaData.AbstractMetaDataPanel = Class.create({
                     return;
                 }
 
+                this.draftNode = new Ext.form.FieldContainer({
+                    xtype: 'container',
+                    flex: 1,
+                    hidden: resp.isDraft === false,
+                    html: t('seo_bundle.panel.draft_note'),
+                    style: {
+                        padding: '5px',
+                        border: '1px solid #6428b4',
+                        background: '#6428b45c',
+                        margin: '0 0 10px 0',
+                        color: 'black'
+                    }
+                });
+
+                this.layout.insert(0, this.draftNode)
+
                 this.buildMetaDataIntegrator(resp.data, resp.configuration, resp.availableLocales);
+
             }.bind(this),
             failure: function () {
                 Ext.Msg.alert(t('error'), t('seo_bundle.panel.error_fetch_data'));
@@ -99,14 +117,17 @@ Seo.MetaData.AbstractMetaDataPanel = Class.create({
         }
     },
 
-    save: function () {
+    save: function (task) {
 
         var integratorValues = this.getIntegratorValues();
+
+        this.draftNode.setHidden(task === 'publish');
 
         Ext.Ajax.request({
             url: '/admin/seo/meta-data/set-element-meta-data-configuration',
             method: 'POST',
             params: {
+                task: task,
                 integratorValues: Ext.encode(integratorValues),
                 elementType: this.getElementType(),
                 elementId: this.getElementId()

--- a/public/js/plugin.js
+++ b/public/js/plugin.js
@@ -62,12 +62,12 @@ class SeoCore {
 
         const document = ev.detail.document;
 
-        if (ev.detail.task === 'autoSave' || ev.detail.task === 'version') {
+        if (ev.detail.task === 'autoSave') {
             return;
         }
 
         if (document.hasOwnProperty('seoPanel')) {
-            document.seoPanel.save();
+            document.seoPanel.save(ev.detail.task);
         }
     }
 
@@ -75,12 +75,12 @@ class SeoCore {
 
         const object = ev.detail.object;
 
-        if (ev.detail.task === 'autoSave' || ev.detail.task === 'version') {
+        if (ev.detail.task === 'autoSave') {
             return;
         }
 
         if (object.hasOwnProperty('seoPanel')) {
-            object.seoPanel.save();
+            object.seoPanel.save(ev.detail.task);
         }
     }
 

--- a/src/EventListener/ElementMetaDataListener.php
+++ b/src/EventListener/ElementMetaDataListener.php
@@ -25,11 +25,11 @@ class ElementMetaDataListener implements EventSubscriberInterface
 
     public function handleDocumentDeletion(DocumentEvent $event): void
     {
-        $this->elementMetaDataManager->deleteElementData('document', $event->getDocument()->getId());
+        $this->elementMetaDataManager->deleteElementData('document', $event->getDocument()->getId(), null);
     }
 
     public function handleObjectDeletion(DataObjectEvent $event): void
     {
-        $this->elementMetaDataManager->deleteElementData('object', $event->getObject()->getId());
+        $this->elementMetaDataManager->deleteElementData('object', $event->getObject()->getId(), null);
     }
 }

--- a/src/Manager/ElementMetaDataManager.php
+++ b/src/Manager/ElementMetaDataManager.php
@@ -199,7 +199,7 @@ class ElementMetaDataManager implements ElementMetaDataManagerInterface
         return $metaDataIntegrator->getPreviewParameter($element, $template, $data);
     }
 
-    public function deleteElementData(string $elementType, int $elementId, ?string $releaseType = ElementMetaData::RELEASE_TYPE_PUBLIC): void
+    public function deleteElementData(string $elementType, int $elementId, ?string $releaseType = ElementMetaDataInterface::RELEASE_TYPE_PUBLIC): void
     {
         $elementData = $this->elementMetaDataRepository->findAll($elementType, $elementId, $releaseType);
 
@@ -217,7 +217,7 @@ class ElementMetaDataManager implements ElementMetaDataManagerInterface
     /**
      * @return array<int, ElementMetaDataInterface>
      */
-    protected function checkForLegacyData(array $elements, string $elementType, int $elementId, string $releaseType = ElementMetaData::RELEASE_TYPE_PUBLIC): array
+    protected function checkForLegacyData(array $elements, string $elementType, int $elementId, string $releaseType = ElementMetaDataInterface::RELEASE_TYPE_PUBLIC): array
     {
         // as soon we have configured seo elements,
         // we'll never check the document again. It's all about performance.

--- a/src/Manager/ElementMetaDataManagerInterface.php
+++ b/src/Manager/ElementMetaDataManagerInterface.php
@@ -2,6 +2,7 @@
 
 namespace SeoBundle\Manager;
 
+use SeoBundle\Model\ElementMetaData;
 use SeoBundle\Model\ElementMetaDataInterface;
 
 interface ElementMetaDataManagerInterface
@@ -13,7 +14,7 @@ interface ElementMetaDataManagerInterface
     /**
      * @return array<int, ElementMetaDataInterface>
      */
-    public function getElementData(string $elementType, int $elementId): array;
+    public function getElementData(string $elementType, int $elementId, bool $allowDraftReleaseType = false): array;
 
     public function getElementDataForBackend(string $elementType, int $elementId): array;
 
@@ -21,9 +22,16 @@ interface ElementMetaDataManagerInterface
 
     public function saveElementDataFromXliffImport(string $elementType, int $elementId, array $rawData, string $locale): void;
 
-    public function saveElementData(string $elementType, int $elementId, string $integratorName, array $data, bool $merge = false): void;
+    public function saveElementData(
+        string $elementType,
+        int $elementId,
+        string $integratorName,
+        array $data,
+        bool $merge = false,
+        string $releaseType = ElementMetaDataInterface::RELEASE_TYPE_PUBLIC
+    ): void;
 
     public function generatePreviewDataForElement(string $elementType, int $elementId, string $integratorName, ?string $template, array $data): array;
 
-    public function deleteElementData(string $elementType, int $elementId): void;
+    public function deleteElementData(string $elementType, int $elementId, ?string $releaseType = ElementMetaData::RELEASE_TYPE_PUBLIC): void;
 }

--- a/src/Manager/ElementMetaDataManagerInterface.php
+++ b/src/Manager/ElementMetaDataManagerInterface.php
@@ -2,7 +2,6 @@
 
 namespace SeoBundle\Manager;
 
-use SeoBundle\Model\ElementMetaData;
 use SeoBundle\Model\ElementMetaDataInterface;
 
 interface ElementMetaDataManagerInterface
@@ -33,5 +32,5 @@ interface ElementMetaDataManagerInterface
 
     public function generatePreviewDataForElement(string $elementType, int $elementId, string $integratorName, ?string $template, array $data): array;
 
-    public function deleteElementData(string $elementType, int $elementId, ?string $releaseType = ElementMetaData::RELEASE_TYPE_PUBLIC): void;
+    public function deleteElementData(string $elementType, int $elementId, ?string $releaseType = ElementMetaDataInterface::RELEASE_TYPE_PUBLIC): void;
 }

--- a/src/Migrations/Version20240809095425.php
+++ b/src/Migrations/Version20240809095425.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SeoBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240809095425 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE seo_element_meta_data ADD release_type VARCHAR(255) DEFAULT "public" NOT NULL;');
+        $this->addSql('DROP INDEX element_type_id_integrator ON seo_element_meta_data;');
+        $this->addSql('CREATE UNIQUE INDEX element_type_id_integrator ON seo_element_meta_data (element_type, element_id, integrator, release_type);');
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/src/Model/ElementMetaData.php
+++ b/src/Model/ElementMetaData.php
@@ -9,6 +9,7 @@ class ElementMetaData implements ElementMetaDataInterface
     protected int $elementId;
     protected string $integrator;
     protected array $data = [];
+    protected string $releaseType;
 
     public function setId(int $id): void
     {
@@ -58,5 +59,15 @@ class ElementMetaData implements ElementMetaDataInterface
     public function getData(): array
     {
         return $this->data;
+    }
+
+    public function getReleaseType(): string
+    {
+        return $this->releaseType;
+    }
+
+    public function setReleaseType(string $releaseType): void
+    {
+        $this->releaseType = $releaseType;
     }
 }

--- a/src/Model/ElementMetaDataInterface.php
+++ b/src/Model/ElementMetaDataInterface.php
@@ -4,6 +4,9 @@ namespace SeoBundle\Model;
 
 interface ElementMetaDataInterface
 {
+    public const RELEASE_TYPE_PUBLIC = 'public';
+    public const RELEASE_TYPE_DRAFT = 'draft';
+
     public function getId(): ?int;
 
     public function setElementType(string $elementType): void;
@@ -21,4 +24,8 @@ interface ElementMetaDataInterface
     public function setData(array $data): void;
 
     public function getData(): array;
+
+    public function getReleaseType(): string;
+
+    public function setReleaseType(string $releaseType): void;
 }

--- a/src/Repository/ElementMetaDataRepository.php
+++ b/src/Repository/ElementMetaDataRepository.php
@@ -22,7 +22,7 @@ class ElementMetaDataRepository implements ElementMetaDataRepositoryInterface
         return $this->repository->createQueryBuilder('e');
     }
 
-    public function findAll(string $elementType, int $elementId, ?string $releaseType = ElementMetaData::RELEASE_TYPE_PUBLIC): array
+    public function findAll(string $elementType, int $elementId, ?string $releaseType = ElementMetaDataInterface::RELEASE_TYPE_PUBLIC): array
     {
         $conditions = [
             'elementType' => $elementType,
@@ -40,7 +40,7 @@ class ElementMetaDataRepository implements ElementMetaDataRepositoryInterface
         string $elementType,
         int $elementId,
         string $integrator,
-        string $releaseType = ElementMetaData::RELEASE_TYPE_PUBLIC
+        string $releaseType = ElementMetaDataInterface::RELEASE_TYPE_PUBLIC
     ): ?ElementMetaDataInterface {
         return $this->repository->findOneBy([
             'elementType' => $elementType,

--- a/src/Repository/ElementMetaDataRepository.php
+++ b/src/Repository/ElementMetaDataRepository.php
@@ -4,6 +4,7 @@ namespace SeoBundle\Repository;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\QueryBuilder;
 use SeoBundle\Model\ElementMetaData;
 use SeoBundle\Model\ElementMetaDataInterface;
 
@@ -16,20 +17,36 @@ class ElementMetaDataRepository implements ElementMetaDataRepositoryInterface
         $this->repository = $entityManager->getRepository(ElementMetaData::class);
     }
 
-    public function findAll(string $elementType, int $elementId): array
+    public function getQueryBuilder(): QueryBuilder
     {
-        return $this->repository->findBy([
-            'elementType' => $elementType,
-            'elementId'   => $elementId
-        ]);
+        return $this->repository->createQueryBuilder('e');
     }
 
-    public function findByIntegrator(string $elementType, int $elementId, string $integrator): ?ElementMetaDataInterface
+    public function findAll(string $elementType, int $elementId, ?string $releaseType = ElementMetaData::RELEASE_TYPE_PUBLIC): array
     {
+        $conditions = [
+            'elementType' => $elementType,
+            'elementId'   => $elementId
+        ];
+
+        if ($releaseType !== null) {
+            $conditions['releaseType'] = $releaseType;
+        }
+
+        return $this->repository->findBy($conditions);
+    }
+
+    public function findByIntegrator(
+        string $elementType,
+        int $elementId,
+        string $integrator,
+        string $releaseType = ElementMetaData::RELEASE_TYPE_PUBLIC
+    ): ?ElementMetaDataInterface {
         return $this->repository->findOneBy([
             'elementType' => $elementType,
             'elementId'   => $elementId,
-            'integrator'  => $integrator
+            'integrator'  => $integrator,
+            'releaseType' => $releaseType,
         ]);
     }
 }

--- a/src/Repository/ElementMetaDataRepositoryInterface.php
+++ b/src/Repository/ElementMetaDataRepositoryInterface.php
@@ -3,7 +3,6 @@
 namespace SeoBundle\Repository;
 
 use Doctrine\ORM\QueryBuilder;
-use SeoBundle\Model\ElementMetaData;
 use SeoBundle\Model\ElementMetaDataInterface;
 
 interface ElementMetaDataRepositoryInterface
@@ -13,7 +12,7 @@ interface ElementMetaDataRepositoryInterface
     /**
      * @return array<int, ElementMetaDataInterface>
      */
-    public function findAll(string $elementType, int $elementId, ?string $releaseType = ElementMetaData::RELEASE_TYPE_PUBLIC): array;
+    public function findAll(string $elementType, int $elementId, ?string $releaseType = ElementMetaDataInterface::RELEASE_TYPE_PUBLIC): array;
 
-    public function findByIntegrator(string $elementType, int $elementId, string $integrator, string $releaseType = ElementMetaData::RELEASE_TYPE_PUBLIC): ?ElementMetaDataInterface;
+    public function findByIntegrator(string $elementType, int $elementId, string $integrator, string $releaseType = ElementMetaDataInterface::RELEASE_TYPE_PUBLIC): ?ElementMetaDataInterface;
 }

--- a/src/Repository/ElementMetaDataRepositoryInterface.php
+++ b/src/Repository/ElementMetaDataRepositoryInterface.php
@@ -2,14 +2,18 @@
 
 namespace SeoBundle\Repository;
 
+use Doctrine\ORM\QueryBuilder;
+use SeoBundle\Model\ElementMetaData;
 use SeoBundle\Model\ElementMetaDataInterface;
 
 interface ElementMetaDataRepositoryInterface
 {
+    public function getQueryBuilder(): QueryBuilder;
+
     /**
      * @return array<int, ElementMetaDataInterface>
      */
-    public function findAll(string $elementType, int $elementId): array;
+    public function findAll(string $elementType, int $elementId, ?string $releaseType = ElementMetaData::RELEASE_TYPE_PUBLIC): array;
 
-    public function findByIntegrator(string $elementType, int $elementId, string $integrator): ?ElementMetaDataInterface;
+    public function findByIntegrator(string $elementType, int $elementId, string $integrator, string $releaseType = ElementMetaData::RELEASE_TYPE_PUBLIC): ?ElementMetaDataInterface;
 }

--- a/translations/admin.de.yml
+++ b/translations/admin.de.yml
@@ -1,4 +1,5 @@
 seo_bundle.panel_title: 'SEO'
+seo_bundle.panel.draft_note: 'Unveröffentlichte Version!'
 seo_bundle.panel.error_fetch_data: 'Fehler beim Abrufen der SEO-Metadaten.'
 seo_bundle.panel.error_save_data: 'Fehler beim Speichern der SEO-Metadaten.'
 seo_bundle.panel.default_pimcore_disabled: 'Der Standard-SEO-Bereich wurde deaktiviert. Verwenden Sie stattdessen das "SEO"-Panel.'

--- a/translations/admin.en.yml
+++ b/translations/admin.en.yml
@@ -1,4 +1,5 @@
 seo_bundle.panel_title: 'SEO'
+seo_bundle.panel.draft_note: 'Unpublished Version!'
 seo_bundle.panel.error_fetch_data: 'Error while fetching seo metadata.'
 seo_bundle.panel.error_save_data: 'Error while saving seo metadata.'
 seo_bundle.panel.default_pimcore_disabled: 'The default SEO Section has been disabled. Use the "SEO" Panel instead.'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #64 

This PR allows us to save current data as `draft` when saving an unpublished object or hitting the `save draft` button. 

- It does **not** support pimcore versions: Since the SEO panel gets generated for various types (document, object..) we cannot rely on the versioning system
- autosave is also **not** supported